### PR TITLE
Support for original stream deck v2

### DIFF
--- a/src/DeckSurf.SDK.sln
+++ b/src/DeckSurf.SDK.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31321.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeckSurf.SDK", "DeckSurf.SDK\DeckSurf.SDK.csproj", "{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeckSurf.SDK.StartBoard", "DeckSurf.SDK.StartBoard\DeckSurf.SDK.StartBoard.csproj", "{DF0F89F4-B35B-4B16-B2F4-6A959C14D23A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeckSurf.SDK.StartBoard", "DeckSurf.SDK.StartBoard\DeckSurf.SDK.StartBoard.csproj", "{DF0F89F4-B35B-4B16-B2F4-6A959C14D23A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,6 +16,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}.Debug|Any CPU.Build.0 = Debug|x64
 		{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}.Debug|x64.ActiveCfg = Debug|x64
 		{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}.Debug|x64.Build.0 = Debug|x64
 		{F1BBE555-6029-4C52-B369-9AEFE2EDB6A9}.Release|Any CPU.ActiveCfg = Release|x64

--- a/src/DeckSurf.SDK/Core/DeviceManager.cs
+++ b/src/DeckSurf.SDK/Core/DeviceManager.cs
@@ -17,6 +17,7 @@ namespace DeckSurf.SDK.Core
     public class DeviceManager
     {
         private static readonly int SupportedVid = 4057;
+        private static readonly int SupportedVidOriginalV2 = 6940;
 
         /// <summary>
         /// Return a list of connected Stream Deck devices supported by DeckSurf.
@@ -43,6 +44,11 @@ namespace DeckSurf.SDK.Core
                         case DeviceModel.MINI:
                         case DeviceModel.ORIGINAL:
                         case DeviceModel.ORIGINAL_V2:
+                            {
+                                connectedDevices.Add(new StreamDeckV2(device.VendorID, device.ProductID, device.DevicePath, device.GetFriendlyName(), (DeviceModel)device.ProductID));
+                                break;
+                            }
+
                         default:
                             {
                                 // Haven't yet implemented support for other Stream Deck device classes.
@@ -93,6 +99,11 @@ namespace DeckSurf.SDK.Core
         public static bool IsSupported(int vid, int pid)
         {
             if (vid == SupportedVid && Enum.IsDefined(typeof(DeviceModel), (byte)pid))
+            {
+                return true;
+            }
+
+            if (vid == SupportedVidOriginalV2 && Enum.IsDefined(typeof(DeviceModel), (byte)pid))
             {
                 return true;
             }

--- a/src/DeckSurf.SDK/Core/DeviceManager.cs
+++ b/src/DeckSurf.SDK/Core/DeviceManager.cs
@@ -76,6 +76,7 @@ namespace DeckSurf.SDK.Core
                     profile.DeviceIndex <= devices.Count() - 1)
                 {
                     var targetDevice = devices.ElementAt(profile.DeviceIndex);
+                    targetDevice.SetBrightness(50);
                     targetDevice.SetupDeviceButtonMap(profile.ButtonMap);
                     return targetDevice;
                 }

--- a/src/DeckSurf.SDK/DeckSurf.SDK.csproj
+++ b/src/DeckSurf.SDK/DeckSurf.SDK.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Platforms>x64</Platforms>
+    <!--<Platforms>x64</Platforms>-->
     <Company>Den Delimarsky</Company>
     <Authors>Den Delimarsky</Authors>
     <Version>0.0.3</Version>

--- a/src/DeckSurf.SDK/Models/ConnectedDevice.cs
+++ b/src/DeckSurf.SDK/Models/ConnectedDevice.cs
@@ -172,8 +172,8 @@ namespace DeckSurf.SDK.Models
                     {
                         byte[] imageBuffer = File.ReadAllBytes(button.ButtonImagePath);
 
-                        // TODO: Need to make sure that I am using device-agnostic button sizes.
-                        imageBuffer = ImageHelpers.ResizeImage(imageBuffer, DeviceConstants.XLButtonSize, DeviceConstants.XLButtonSize);
+                        ImageHelpers.GetDeviceIconSizes(Model, out var width, out var height, out var emSize);
+                        imageBuffer = ImageHelpers.ResizeImage(imageBuffer, width, height);
                         this.SetKey(button.ButtonIndex, imageBuffer);
                     }
                 }

--- a/src/DeckSurf.SDK/Models/ConnectedDevice.cs
+++ b/src/DeckSurf.SDK/Models/ConnectedDevice.cs
@@ -164,6 +164,15 @@ namespace DeckSurf.SDK.Models
         /// <param name="buttonMap">List of mappings, usually loaded from a configuration file.</param>
         public void SetupDeviceButtonMap(IEnumerable<CommandMapping> buttonMap)
         {
+            for (int i = 0; i < this.ButtonCount - 1; i++)
+            {
+                byte[] imageBuffer = DeviceConstants.XLDefaultBlackButton;
+
+                ImageHelpers.GetDeviceIconSizes(Model, out var width, out var height, out var emSize);
+                imageBuffer = ImageHelpers.ResizeImage(imageBuffer, width, height);
+                this.SetKey(i, imageBuffer);
+            }
+
             foreach (var button in buttonMap)
             {
                 if (button.ButtonIndex <= this.ButtonCount - 1)

--- a/src/DeckSurf.SDK/Models/Devices/StreamDeckV2.cs
+++ b/src/DeckSurf.SDK/Models/Devices/StreamDeckV2.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Den Delimarsky
+// Den Delimarsky licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using DeckSurf.SDK.Models;
+
+namespace DeckSurf.SDK.Models.Devices
+{
+    internal class StreamDeckV2 : ConnectedDevice
+    {
+        public StreamDeckV2(int vid, int pid, string path, string name, DeviceModel model) : base(vid, pid, path, name, model)
+        {
+        }
+    }
+}

--- a/src/DeckSurf.SDK/Util/ImageHelpers.cs
+++ b/src/DeckSurf.SDK/Util/ImageHelpers.cs
@@ -8,6 +8,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
+using DeckSurf.SDK.Core;
 using DeckSurf.SDK.Models;
 
 namespace DeckSurf.SDK.Util
@@ -178,6 +179,30 @@ namespace DeckSurf.SDK.Util
             }
 
             throw Marshal.GetExceptionForHR((int)hr);
+        }
+
+        public static void GetDeviceIconSizes(DeviceModel device, out int width, out int height, out int emSize)
+        {
+            if (device == DeviceModel.ORIGINAL_V2)
+            {
+                width = DeviceConstants.UniversalButtonSize;
+                height = DeviceConstants.UniversalButtonSize;
+                emSize = 72;
+            }
+
+            if (device == DeviceModel.XL)
+            {
+                width = DeviceConstants.XLButtonSize;
+                height = DeviceConstants.XLButtonSize;
+                emSize = 94;
+            }
+
+            else
+            {
+                width = DeviceConstants.UniversalButtonSize;
+                height = DeviceConstants.UniversalButtonSize;
+                emSize = 72;
+            }
         }
     }
 }


### PR DESCRIPTION
I implemented support for my own v2 stream deck into your sdk and have been using the code daily for a couple of months now.

There are some loose ends but I felt like maybe this would be beneficial to others so I'm trying my luck with a pull request.

Setting of brightness didn't seem implemented except for the hardware support for it so I took the freedom of hardcoding 50% brightness on device setup. Ideally it should be implemented as a profile setting.
